### PR TITLE
Fix save shortcut to handle uppercase 'S' key

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -360,7 +360,7 @@ const Editor = () => {
     // Add keyboard shortcut for Ctrl+S (Windows/Linux) and Cmd+S (macOS)
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
-            if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+            if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's') {
                 event.preventDefault();
                 if (action === 'edit') {
                     save();


### PR DESCRIPTION
Updated the keyboard shortcut handler to use event.key.toLowerCase() for detecting 's', ensuring the save action works regardless of key case.