### PR TITLE
Show modal on Ctrl+Enter for new action in Editor

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -364,6 +364,8 @@ const Editor = () => {
                 event.preventDefault();
                 if (action === 'edit') {
                     save();
+                } else if (action === 'new') {
+                    setModalVisible(true);
                 }
             }
         };


### PR DESCRIPTION
Added logic to display the modal when Ctrl+Enter is pressed and the current action is 'new', improving the user workflow for creating new items.